### PR TITLE
[ADMIN] Improving the wording of current licenses

### DIFF
--- a/license.md
+++ b/license.md
@@ -1,8 +1,11 @@
 # Working Group Outputs
 
-All repositories and files in this [FOCUS GitHub Organization](https://github.com/FinOps-Open-Cost-and-Usage-Spec) are covered by the following license.
+All repositories and files in this [FOCUS GitHub Organization](https://github.com/FinOps-Open-Cost-and-Usage-Spec) are covered by the following license. For specific details, see the [Working Group's charter](FOCUS_-_Membership_Agreement_Package_for_use.pdf), available in this repository.
 
-## License
+Materials in this repository other than source code are provided as follows:
+
+Copyright (c) 2023 - 2024 Joint Development Foundation Projects, LLC, FinOps Open Cost and Usage Specification (FOCUS) Series and its contributors. All rights reserved. The materials are subject to the Creative Commons Attribution 4.0 International license (CC-BY-4.0), available at https://creativecommons.org/licenses/by/4.0/legalcode.
+
 
 Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
 
@@ -14,3 +17,18 @@ This work is licensed under a
 [cc-by]: http://creativecommons.org/licenses/by/4.0/
 [cc-by-image]: https://i.creativecommons.org/l/by/4.0/88x31.png
 [cc-by-shield]: https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg
+
+THESE MATERIALS ARE PROVIDED "AS IS." The owners and contributors expressly
+disclaim any warranties (express, implied, or otherwise), including implied
+warranties of merchantability, non-infringement, fitness for a particular
+purpose, or title, related to the materials. The entire risk as to
+implementing or otherwise using the materials is assumed by the implementer
+and user. IN NO EVENT WILL THE OWNERS AND CONTRIBUTORS BE LIABLE TO ANY
+OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR
+CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND
+WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT, WHETHER BASED ON
+BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR
+NOT THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The patent mode selected for materials developed by this Working Group (other
+than source code) is W3C Mode, as set forth in Appendix B, Patent Policy Option 4.

--- a/license.md
+++ b/license.md
@@ -4,12 +4,12 @@ All repositories and files in this [FOCUS GitHub Organization](https://github.co
 
 Materials in this repository other than source code are provided as follows:
 
-Copyright (c) 2023 - 2024 Joint Development Foundation Projects, LLC, FinOps Open Cost and Usage Specification (FOCUS) Series and its contributors. All rights reserved. The materials are subject to the Creative Commons Attribution 4.0 International license (CC-BY-4.0), available at https://creativecommons.org/licenses/by/4.0/legalcode.
+Copyright (c) Joint Development Foundation Projects, LLC, FinOps Open Cost and Usage Specification (FOCUS) Series and its contributors. The materials in this repository are made available under the Creative Commons Attribution 4.0 International license (CC-BY-4.0), available at https://creativecommons.org/licenses/by/4.0/legalcode.
 
 
 Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
 
-This work is licensed under a
+This work is made available under
 [Creative Commons Attribution 4.0 International License][cc-by].
 
 [![CC BY 4.0][cc-by-image]][cc-by]

--- a/license.md
+++ b/license.md
@@ -9,7 +9,7 @@ Copyright (c) Joint Development Foundation Projects, LLC, FinOps Open Cost and U
 
 Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
 
-This work is made available under
+This work is made available under:
 [Creative Commons Attribution 4.0 International License][cc-by].
 
 [![CC BY 4.0][cc-by-image]][cc-by]
@@ -18,17 +18,18 @@ This work is made available under
 [cc-by-image]: https://i.creativecommons.org/l/by/4.0/88x31.png
 [cc-by-shield]: https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg
 
-THESE MATERIALS ARE PROVIDED "AS IS." The owners and contributors expressly
-disclaim any warranties (express, implied, or otherwise), including implied
-warranties of merchantability, non-infringement, fitness for a particular
-purpose, or title, related to the materials. The entire risk as to
-implementing or otherwise using the materials is assumed by the implementer
-and user. IN NO EVENT WILL THE OWNERS AND CONTRIBUTORS BE LIABLE TO ANY
-OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR
-CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND
-WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT, WHETHER BASED ON
-BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR
-NOT THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THESE MATERIALS ARE PROVIDED “AS IS.” The parties expressly disclaim 
+any warranties (express, implied, or otherwise), including implied 
+warranties of merchantability, non-infringement, fitness for a particular 
+purpose, or title, related to the materials. The entire risk as to 
+implementing or otherwise using the materials is assumed by the 
+implementer and user. IN NO EVENT WILL THE PARTIES BE LIABLE TO ANY 
+OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, 
+OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF 
+ANY KIND WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT, 
+WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR 
+OTHERWISE, AND WHETHER OR NOT THE OTHER MEMBER HAS BEEN ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE.
 
 The patent mode selected for materials developed by this Working Group (other
 than source code) is W3C Mode, as set forth in Appendix B, Patent Policy Option 4.


### PR DESCRIPTION
The current license should contain the disclaimer notice in the FOCUS  Project Charter, section `12. Disclaimers for Distribution`. 
According to the Working Group Charter, the incoming copyright license is `Copyright Grant to Project.` This should be mentioned in the license file. Although it is not mentioned in the Working Group Charter, the group has decided to release the specification using Creative Commons Attribution 4.0. Therefore, I am keeping all the existing references to CC BY 4.0.

Finally, I included the patent mode, W3C Mode, which needed to be added to the license. 