### PR TITLE
[ADMIN] update FOCUS Roles & Tasks

### DIFF
--- a/operating_procedures.md
+++ b/operating_procedures.md
@@ -40,22 +40,37 @@ FOCUS Operating Procedures
 
   Organizational Roles involved in performing work within the Project or as a member of a FOCUS Working Group are:
 
-  * FOCUS Group members (Contributors)
-  * FOCUS Group Maintainer
-  * FOCUS Group Chair(s)
+  * Contributors (Members)
+  * Editors
+  * Task Force Conveners
+  * Working Group Chair
+  * Maintainers
   * Support Staff
 
-### 2.2.1 FOCUS Group members (Contributors)
 
-  An FOCUS Group Member or Contributor is any individual creating content or commenting on an issue or pull request.
+**Contributors**
 
-  FOCUS Contributors MUST read the Project documentation (e.g.: this operational document, contribution guidelines, [README](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/blob/working_draft/README.md), [CONTRIBUTING](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/blob/working_draft/CONTRIBUTING.md), and [RELEASE_PLANNING](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/blob/working_draft/RELEASE-PLANNING.md) documents) before attempting to submit an Issue or Pull Request.
+An FOCUS Group Member or Contributor is any individual creating content or commenting on an issue or pull request.
 
-  Contributors of the FOCUS project play a fundamental role in maintaining the collaborative and dynamic nature of the project by contributing to a variety of tasks. Their responsibilities encompass actively participating in members' and task force meetings, as well as engaging on GitHub. Contributors are crucial in labeling issues and pull requests, ensuring that these accurately reflect the content's nature and urgency. They are also involved in reviewing and providing constructive feedback on pull requests and issues, thus directly contributing to the refinement of project specifications and adherence to editorial guidelines.
+FOCUS Contributors MUST read the Project documentation (e.g.: this operational document, contribution guidelines, [README](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/blob/working_draft/README.md), [CONTRIBUTING](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/blob/working_draft/CONTRIBUTING.md), and [RELEASE_PLANNING](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/blob/working_draft/RELEASE-PLANNING.md) documents) before attempting to submit an Issue or Pull Request.
 
-  In collaboration with Editors and Maintainers, Contributors help drive the evolution of project standards and participate in decision-making processes. Their engagement extends to the wider community through participation in discussions, staying informed about project updates and continuously enhancing their understanding of the evolving standards. Additionally, they provide essential input on project documentation, advocating for clarity, accuracy, and accessibility to ensure the documentation serves as a reliable resource.
+Contributors of the FOCUS project play a fundamental role in maintaining the collaborative and dynamic nature of the project by contributing to a variety of tasks. Their responsibilities encompass actively participating in members' and task force meetings, as well as engaging on GitHub. Contributors are crucial in labeling issues and pull requests, ensuring that these accurately reflect the content's nature and urgency. They are also involved in reviewing and providing constructive feedback on pull requests and issues, thus directly contributing to the refinement of project specifications and adherence to editorial guidelines.
 
-  These are some of the tasks where Contributors are expected to collaborate:
+In collaboration with Editors and Maintainers, Contributors help drive the evolution of project standards and participate in decision-making processes. Their engagement extends to the wider community through participation in discussions, staying informed about project updates and continuously enhancing their understanding of the evolving standards. Additionally, they provide essential input on project documentation, advocating for clarity, accuracy, and accessibility to ensure the documentation serves as a reliable resource.
+
+**Editors**
+
+Editors within the FOCUS project are tasked with the crucial role of overseeing the quality and accuracy of documentation. Editor responsibilities include incorporating and notifying Members of the incorporation of editorial pull requests, managing document updates, and maintaining standards across all project materials. Editors collaborate closely with team members and task force conveners to refine project specifications and integrate new findings effectively. Additionally, they are responsible for enforcing editorial guidelines to ensure all contributions meet the project's quality expectations and are in line with established practices. This role is pivotal in sustaining the integrity and progression of the FOCUS project's documentation efforts.
+
+**Task Force Conveners**
+
+**Working Group Members Chair**
+
+**Maintainers**
+
+**Program Manager**
+
+
 
 * **Suggest Labels for PRs and Issues**
   * Propose appropriate [labels](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/labels) to qualify items created (Pull Requests and Issues) at the creation time.

--- a/operating_procedures.md
+++ b/operating_procedures.md
@@ -40,16 +40,49 @@ FOCUS Operating Procedures
 
   Organizational Roles involved in performing work within the Project or as a member of a FOCUS Working Group are:
 
-  * FOCUS Group members (FG member)
+  * FOCUS Group members (Contributors)
   * FOCUS Group Maintainer
   * FOCUS Group Chair(s)
   * Support Staff
 
-### 2.2.1 FOCUS Group members (FG member)
+### 2.2.1 FOCUS Group members (Contributors)
 
-  An FG member is any individual creating content or commenting on an issue or pull request.
+  An FOCUS Group Member or Contributor is any individual creating content or commenting on an issue or pull request.
 
-  FG members MUST read the Project documentation (e.g.: this operational document, contribution guidelines, README, Contributing, and Release Planning documents) before attempting to submit an Issue or Pull Request
+  FOCUS Contributors MUST read the Project documentation (e.g.: this operational document, contribution guidelines, README, Contributing, and RELEASE_PLANNING documents) before attempting to submit an Issue or Pull Request.
+
+  Contributors of the FOCUS project play a fundamental role in maintaining the collaborative and dynamic nature of the project by contributing to a variety of tasks. Their responsibilities encompass actively participating in members' and task force meetings, as well as engaging on GitHub. Contributors are crucial in labeling issues and pull requests, ensuring that these accurately reflect the content's nature and urgency. They are also involved in reviewing and providing constructive feedback on pull requests and issues, thus directly contributing to the refinement of project specifications and adherence to editorial guidelines.
+
+  In collaboration with Editors and Maintainers, Contributors help drive the evolution of project standards and participate in decision-making processes. Their engagement extends to the wider community through participation in discussions, staying informed about project updates and continuously enhancing their understanding of the evolving standards. Additionally, they provide essential input on project documentation, advocating for clarity, accuracy, and accessibility to ensure the documentation serves as a reliable resource.
+
+  These are some of the tasks where Contributors are expected to collaborate:
+
+* **Suggest Labels for PRs and Issues**
+  * Propose appropriate [labels](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/labels) to qualify items created (Pull Requests and Issues) at the creation time.
+  * Ensure labels reflect the nature and priority of each item.
+
+* **Review and Comment on PRs and Issues**
+  * Review [Pull Requests](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pulls) and [Issues](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/issues), providing constructive feedback and suggestions.
+  * Engage in discussions to help refine and improve submissions.
+  * Review and comment on issues and PRs related to [Task Forces](https://github.com/orgs/FinOps-Open-Cost-and-Usage-Spec/projects/5), providing feedback and suggestions to enhance their work.
+  * Follow [Editorial Guidelines](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/Editorial_Guidelines.md) and rules when contributing to the FOCUS Specifications.
+
+* **Collaborate with Editors and Maintainers**
+  * Work closely with editors and maintainers to improve the specifications.
+  * Contribute to discussions and decision-making processes.
+
+* **Engage with the Community**
+  * Participate in community discussions and activities.
+  * Encourage new members to contribute and support their onboarding process.
+
+* **Stay Informed and Updated**
+  * Keep up-to-date with project developments and changes.
+  * Continuously learn about the standards and guidelines being developed.
+
+* **Provide Input on Documentation**
+  * Review project documentation and suggest improvements.
+  * Ensure that documentation is clear, accurate, and accessible.
+
 
 ### 2.2.2 FOCUS Group Maintainer
   

--- a/operating_procedures.md
+++ b/operating_procedures.md
@@ -198,6 +198,97 @@ The FinOps FOCUS Project is structured to ensure efficient collaboration and coo
 - **Maintainers**: Engage with stakeholders on technical matters; Ensure stakeholder expectations are met.
 - **Program Manager**: Primary liaison for all stakeholder communication; Integrate feedback into strategic planning; Manage stakeholder relationships.
 
+>Note: the group may decide to render the above content as a table:
+
+<table border="1">
+  <thead>
+    <tr>
+      <th>Grouped Tasks</th>
+      <th>Contributors</th>
+      <th>Editors</th>
+      <th>Task Force Conveners</th>
+      <th>Working Group Chair</th>
+      <th>Maintainers</th>
+      <th>Program Manager</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Create, Review & Feedback</td>
+      <td>Create, review and comment on PRs and issues; Provide constructive feedback</td>
+      <td>Approve editorial PRs; Enforce documentation standards</td>
+      <td>Lead task force meetings to review technical contributions; Approve or reject contributions</td>
+      <td>Lead working group meetings; Oversee comprehensive review processes; Address escalated issues</td>
+      <td>Final review and merge of PRs; Ensure compliance with technical standards; Support Editors</td>
+      <td>Oversee the overall review process; Ensure that project goals are met; Resolve conflicts</td>
+    </tr>
+    <tr>
+      <td>Labeling & Triage</td>
+      <td>Suggest labels for PRs and issues; Participate in labeling discussions</td>
+      <td>Validate and refine labels for editorial consistency</td>
+      <td>Oversee labeling specific to their task force; Ensure technical relevance of labels</td>
+      <td>Monitor overall labeling practices across task forces; Ensure consistency</td>
+      <td>Final approval of labels; Ensure proper categorization; Maintain label definitions</td>
+      <td>Oversee labeling strategy; Ensure alignment with project milestones and objectives</td>
+    </tr>
+    <tr>
+      <td>Collaboration & Coordination</td>
+      <td>Collaborate with Editors and Maintainers; Engage in task force meetings</td>
+      <td>Coordinate with Task Force Conveners; Support cross-team communication</td>
+      <td>Facilitate collaboration within the task force; Coordinate with other conveners and the Working Group Chair</td>
+      <td>Coordinate all task forces; Ensure alignment with project goals; Facilitate inter-task force collaboration</td>
+      <td>Coordinate technical work across teams; Manage integration of contributions; Support cross-functional communication</td>
+      <td>Ensure cohesive collaboration among all teams; Address process issues; Align team efforts with strategic goals</td>
+    </tr>
+    <tr>
+      <td>Community & Engagement</td>
+      <td>Engage with the community; Provide support to new contributors</td>
+      <td>Encourage community participation; Facilitate discussions on editorial improvements</td>
+      <td>Engage with stakeholders; Promote task force activities; Gather feedback</td>
+      <td>Facilitate community discussions; Engage with external stakeholders; Promote the project's mission</td>
+      <td>Foster community engagement; Support new contributors; Mentor community members</td>
+      <td>Primary contact for stakeholders; Maintain stakeholder engagement; Promote project visibility and community involvement</td>
+    </tr>
+    <tr>
+      <td>Documentation & Reporting</td>
+      <td>Contribute to documentation; Advocate for clarity and accessibility</td>
+      <td>Oversee document updates; Ensure accuracy and adherence to editorial standards</td>
+      <td>Document task force activities; Ensure documentation reflects technical accuracy and completeness</td>
+      <td>Ensure comprehensive documentation; Report task force activities to stakeholders; Address documentation gaps</td>
+      <td>Maintain overall documentation; Keep communication channels updated; Ensure repository accuracy</td>
+      <td>Comprehensive documentation; Prepare detailed status reports; Communicate project progress and challenges</td>
+    </tr>
+    <tr>
+      <td>Monitoring & Maintenance</td>
+      <td>Participate in monitoring discussions; Report issues</td>
+      <td>Oversee editorial quality and consistency in documentation</td>
+      <td>Monitor task force-specific contributions; Ensure ongoing relevance and accuracy</td>
+      <td>Monitor overall project quality; Ensure task forces are meeting their objectives; Address quality issues</td>
+      <td>Regular monitoring of repositories; Ensure technical accuracy and compliance; Implement best practices</td>
+      <td>Monitor overall project health and adherence to timelines; Ensure milestones are met</td>
+    </tr>
+    <tr>
+      <td>Learning & Improvement</td>
+      <td>Stay informed and updated; Participate in training sessions</td>
+      <td>Conduct editorial reviews; Recommend improvements based on best practices</td>
+      <td>Facilitate technical learning within the task force; Implement improvements based on feedback</td>
+      <td>Lead continuous improvement initiatives; Encourage innovation and the adoption of best practices</td>
+      <td>Continuous learning and implementation of new technologies; Mentor team members</td>
+      <td>Lead and promote a culture of continuous improvement; Facilitate training and professional development</td>
+    </tr>
+    <tr>
+      <td>Stakeholder Management</td>
+      <td>Provide feedback from the community; Participate in stakeholder discussions</td>
+      <td>N/A</td>
+      <td>Engage with stakeholders for feedback on task force outputs; Ensure stakeholder needs are addressed</td>
+      <td>Serve as the primary liaison for stakeholders; Integrate stakeholder feedback into the project</td>
+      <td>Engage with stakeholders on technical matters; Ensure stakeholder expectations are met</td>
+      <td>Primary liaison for all stakeholder communication; Integrate feedback into strategic planning; Manage stakeholder relationships</td>
+    </tr>
+  </tbody>
+</table>
+
+
 
 # 3\. Membership Benefits
 

--- a/operating_procedures.md
+++ b/operating_procedures.md
@@ -49,7 +49,7 @@ FOCUS Operating Procedures
 
   An FOCUS Group Member or Contributor is any individual creating content or commenting on an issue or pull request.
 
-  FOCUS Contributors MUST read the Project documentation (e.g.: this operational document, contribution guidelines, README, Contributing, and RELEASE_PLANNING documents) before attempting to submit an Issue or Pull Request.
+  FOCUS Contributors MUST read the Project documentation (e.g.: this operational document, contribution guidelines, [README](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/blob/working_draft/README.md), [CONTRIBUTING](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/blob/working_draft/CONTRIBUTING.md), and [RELEASE_PLANNING](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/blob/working_draft/RELEASE-PLANNING.md) documents) before attempting to submit an Issue or Pull Request.
 
   Contributors of the FOCUS project play a fundamental role in maintaining the collaborative and dynamic nature of the project by contributing to a variety of tasks. Their responsibilities encompass actively participating in members' and task force meetings, as well as engaging on GitHub. Contributors are crucial in labeling issues and pull requests, ensuring that these accurately reflect the content's nature and urgency. They are also involved in reviewing and providing constructive feedback on pull requests and issues, thus directly contributing to the refinement of project specifications and adherence to editorial guidelines.
 

--- a/operating_procedures.md
+++ b/operating_procedures.md
@@ -40,15 +40,15 @@ FOCUS Operating Procedures
 
   Organizational Roles involved in performing work within the Project or as a member of a FOCUS Working Group are:
 
-  * Contributors (Members)
-  * Editors
-  * Task Force Conveners
-  * Working Group Chair
-  * Maintainers
-  * Support Staff
+  * FOCUS Group Contributor (Members)
+  * FOCUS Group Editor
+  * FOCUS Group Task Force Convener
+  * FOCUS Group Maintainers
+  * FOCUS Working Group Chair
+  * FOCUS Group Support Staff
 
 
-**Contributors**
+### 2.2.1 Contributor
 
 An FOCUS Group Member or Contributor is any individual creating content or commenting on an issue or pull request.
 
@@ -58,48 +58,16 @@ Contributors of the FOCUS project play a fundamental role in maintaining the col
 
 In collaboration with Editors and Maintainers, Contributors help drive the evolution of project standards and participate in decision-making processes. Their engagement extends to the wider community through participation in discussions, staying informed about project updates and continuously enhancing their understanding of the evolving standards. Additionally, they provide essential input on project documentation, advocating for clarity, accuracy, and accessibility to ensure the documentation serves as a reliable resource.
 
-**Editors**
+### 2.2.2 Editor
 
 Editors within the FOCUS project are tasked with the crucial role of overseeing the quality and accuracy of documentation. Editor responsibilities include incorporating and notifying Members of the incorporation of editorial pull requests, managing document updates, and maintaining standards across all project materials. Editors collaborate closely with team members and task force conveners to refine project specifications and integrate new findings effectively. Additionally, they are responsible for enforcing editorial guidelines to ensure all contributions meet the project's quality expectations and are in line with established practices. This role is pivotal in sustaining the integrity and progression of the FOCUS project's documentation efforts.
 
-**Task Force Conveners**
+### 2.2.3 Task Force Convener
 
-**Working Group Members Chair**
-
-**Maintainers**
-
-**Program Manager**
+Task Force Conveners are dedicated Maintainers within the FinOps FOCUS project who take on the responsibility of leading specific technical workstreams or topics within Task Forces. This leadership role involves guiding the development and implementation of specialized areas of the project, ensuring that all activities align with the project's broader objectives. Conveners are essential in driving detailed technical work, fostering collaboration, and maintaining high standards within their respective domains.
 
 
-
-* **Suggest Labels for PRs and Issues**
-  * Propose appropriate [labels](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/labels) to qualify items created (Pull Requests and Issues) at the creation time.
-  * Ensure labels reflect the nature and priority of each item.
-
-* **Review and Comment on PRs and Issues**
-  * Review [Pull Requests](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/pulls) and [Issues](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/issues), providing constructive feedback and suggestions.
-  * Engage in discussions to help refine and improve submissions.
-  * Review and comment on issues and PRs related to [Task Forces](https://github.com/orgs/FinOps-Open-Cost-and-Usage-Spec/projects/5), providing feedback and suggestions to enhance their work.
-  * Follow [Editorial Guidelines](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/Editorial_Guidelines.md) and rules when contributing to the FOCUS Specifications.
-
-* **Collaborate with Editors and Maintainers**
-  * Work closely with editors and maintainers to improve the specifications.
-  * Contribute to discussions and decision-making processes.
-
-* **Engage with the Community**
-  * Participate in community discussions and activities.
-  * Encourage new members to contribute and support their onboarding process.
-
-* **Stay Informed and Updated**
-  * Keep up-to-date with project developments and changes.
-  * Continuously learn about the standards and guidelines being developed.
-
-* **Provide Input on Documentation**
-  * Review project documentation and suggest improvements.
-  * Ensure that documentation is clear, accurate, and accessible.
-
-
-### 2.2.2 FOCUS Group Maintainer
+### 2.2.4 FOCUS Group Maintainer
   
   FG Maintainers are a subset of the FOCUS Group members who have been given write access to one or more FOCUS Working Group repositories within the FOCUS Project's Github organization. They will advance the day-to-day evolution of the specification and related work products.
 
@@ -121,7 +89,7 @@ Editors within the FOCUS project are tasked with the crucial role of overseeing 
 
   An FG may select a new FG Maintainer or FG Maintainers upon Approval of the FG members, with the approval of the FG’s Chair.
 
-### 2.2.3 FOCUS Group Chair(s)
+### 2.2.5 FOCUS Group Chair(s)
 
   Chair(s) are a subset of the FOCUS Group members and are responsible for organizing activities around work product(s) developed by the FG, including:
   
@@ -145,7 +113,7 @@ Editors within the FOCUS project are tasked with the crucial role of overseeing 
 
   The work and progress of the group is appropriately communicated through regular status reports to the SC. The Chair(s) MAY delegate tasks to other Chair(s).
 
-### 2.2.4 Support Staff
+### 2.2.6 Support Staff
 
   Where possible the FinOps Foundation staff will support the operations of the FOCUS Project. This may include:
 
@@ -153,6 +121,83 @@ Editors within the FOCUS project are tasked with the crucial role of overseeing 
   * Project Management
   * Contractor time for dedicated contributions
   * Review and feedback on operational and technical content
+
+  > Note: The following section outlines the responsibilities and tasks specific to the Program Manager role.
+
+### FinOps FOCUS Project Task Organization
+The FinOps FOCUS Project is structured to ensure efficient collaboration and coordination among various roles, each contributing to the overall success and continuous improvement of the project. The key tasks include creating, reviewing, and providing feedback on pull requests, managing labeling and triage, fostering community engagement, and maintaining comprehensive documentation. The project also emphasizes collaboration across teams, monitoring and maintaining project quality, and continuous learning. Stakeholder management is central to aligning the project with external needs and expectations. Each role, from Contributors to the Program Manager, plays a vital part in driving the project's mission forward, ensuring technical standards are met and fostering a supportive and inclusive community.
+
+#### 1. Create, Review & Feedback
+
+- **Contributors**: Create, review and comment on PRs and issues; Provide constructive feedback.
+- **Editors**: Approve editorial PRs; Enforce documentation standards.
+- **Task Force Conveners**: Lead task force meetings to review technical contributions; Approve or reject contributions.
+- **Working Group Chair**: Lead working group meetings; Oversee comprehensive review processes; Address escalated issues.
+- **Maintainers**: Final review and merge of PRs; Ensure compliance with technical standards; Support Editors.
+- **Program Manager**: Oversee the overall review process; Ensure that project goals are met; Resolve conflicts.
+
+#### 2. Labeling & Triage
+
+- **Contributors**: Suggest labels for PRs and issues; Participate in labeling discussions.
+- **Editors**: Validate and refine labels for editorial consistency.
+- **Task Force Conveners**: Oversee labeling specific to their task force; Ensure technical relevance of labels.
+- **Working Group Chair**: Monitor overall labeling practices across task forces; Ensure consistency.
+- **Maintainers**: Final approval of labels; Ensure proper categorization; Maintain label definitions.
+- **Program Manager**: Oversee labeling strategy; Ensure alignment with project milestones and objectives.
+
+#### 3. Collaboration & Coordination
+
+- **Contributors**: Collaborate with Editors and Maintainers; Engage in task force meetings.
+- **Editors**: Coordinate with Task Force Conveners; Support cross-team communication.
+- **Task Force Conveners**: Facilitate collaboration within the task force; Coordinate with other conveners and the Working Group Chair.
+- **Working Group Chair**: Coordinate all task forces; Ensure alignment with project goals; Facilitate inter-task force collaboration.
+- **Maintainers**: Coordinate technical work across teams; Manage integration of contributions; Support cross-functional communication.
+- **Program Manager**: Ensure cohesive collaboration among all teams; Address process issues; Align team efforts with strategic goals.
+
+#### 4. Community & Engagement
+
+- **Contributors**: Engage with the community; Provide support to new contributors.
+- **Editors**: Encourage community participation; Facilitate discussions on editorial improvements.
+- **Task Force Conveners**: Engage with stakeholders; Promote task force activities; Gather feedback.
+- **Working Group Chair**: Facilitate community discussions; Engage with external stakeholders; Promote the project's mission.
+- **Maintainers**: Foster community engagement; Support new contributors; Mentor community members.
+- **Program Manager**: Primary contact for stakeholders; Maintain stakeholder engagement; Promote project visibility and community involvement.
+
+#### 5. Documentation & Reporting
+
+- **Contributors**: Contribute to documentation; Advocate for clarity and accessibility.
+- **Editors**: Oversee document updates; Ensure accuracy and adherence to editorial standards.
+- **Task Force Conveners**: Document task force activities; Ensure documentation reflects technical accuracy and completeness.
+- **Working Group Chair**: Ensure comprehensive documentation; Report task force activities to stakeholders; Address documentation gaps.
+- **Maintainers**: Maintain overall documentation; Keep communication channels updated; Ensure repository accuracy.
+- **Program Manager**: Comprehensive documentation; Prepare detailed status reports; Communicate project progress and challenges.
+
+#### 6. Monitoring & Maintenance
+
+- **Contributors**: Participate in monitoring discussions; Report issues.
+- **Editors**: Oversee editorial quality and consistency in documentation.
+- **Task Force Conveners**: Monitor task force-specific contributions; Ensure ongoing relevance and accuracy.
+- **Working Group Chair**: Monitor overall project quality; Ensure task forces are meeting their objectives; Address quality issues.
+- **Maintainers**: Regular monitoring of repositories; Ensure technical accuracy and compliance; Implement best practices.
+- **Program Manager**: Monitor overall project health and adherence to timelines; Ensure milestones are met.
+
+#### 7. Learning & Improvement
+
+- **Contributors**: Stay informed and updated; Participate in training sessions.
+- **Editors**: Conduct editorial reviews; Recommend improvements based on best practices.
+- **Task Force Conveners**: Facilitate technical learning within the task force; Implement improvements based on feedback.
+- **Working Group Chair**: Lead continuous improvement initiatives; Encourage innovation and the adoption of best practices.
+- **Maintainers**: Continuous learning and implementation of new technologies; Mentor team members.
+- **Program Manager**: Lead and promote a culture of continuous improvement; Facilitate training and professional development.
+
+#### 8. Stakeholder Management
+
+- **Contributors**: Provide feedback from the community; Participate in stakeholder discussions.
+- **Task Force Conveners**: Engage with stakeholders for feedback on task force outputs; Ensure stakeholder needs are addressed.
+- **Working Group Chair**: Serve as the primary liaison for stakeholders; Integrate stakeholder feedback into the project.
+- **Maintainers**: Engage with stakeholders on technical matters; Ensure stakeholder expectations are met.
+- **Program Manager**: Primary liaison for all stakeholder communication; Integrate feedback into strategic planning; Manage stakeholder relationships.
+
 
 # 3\. Membership Benefits
 

--- a/operating_procedures.md
+++ b/operating_procedures.md
@@ -127,78 +127,7 @@ Task Force Conveners are dedicated Maintainers within the FinOps FOCUS project w
 ### FinOps FOCUS Project Task Organization
 The FinOps FOCUS Project is structured to ensure efficient collaboration and coordination among various roles, each contributing to the overall success and continuous improvement of the project. The key tasks include creating, reviewing, and providing feedback on pull requests, managing labeling and triage, fostering community engagement, and maintaining comprehensive documentation. The project also emphasizes collaboration across teams, monitoring and maintaining project quality, and continuous learning. Stakeholder management is central to aligning the project with external needs and expectations. Each role, from Contributors to the Program Manager, plays a vital part in driving the project's mission forward, ensuring technical standards are met and fostering a supportive and inclusive community.
 
-#### 1. Create, Review & Feedback
-
-- **Contributors**: Create, review and comment on PRs and issues; Provide constructive feedback.
-- **Editors**: Approve editorial PRs; Enforce documentation standards.
-- **Task Force Conveners**: Lead task force meetings to review technical contributions; Approve or reject contributions.
-- **Working Group Chair**: Lead working group meetings; Oversee comprehensive review processes; Address escalated issues.
-- **Maintainers**: Final review and merge of PRs; Ensure compliance with technical standards; Support Editors.
-- **Program Manager**: Oversee the overall review process; Ensure that project goals are met; Resolve conflicts.
-
-#### 2. Labeling & Triage
-
-- **Contributors**: Suggest labels for PRs and issues; Participate in labeling discussions.
-- **Editors**: Validate and refine labels for editorial consistency.
-- **Task Force Conveners**: Oversee labeling specific to their task force; Ensure technical relevance of labels.
-- **Working Group Chair**: Monitor overall labeling practices across task forces; Ensure consistency.
-- **Maintainers**: Final approval of labels; Ensure proper categorization; Maintain label definitions.
-- **Program Manager**: Oversee labeling strategy; Ensure alignment with project milestones and objectives.
-
-#### 3. Collaboration & Coordination
-
-- **Contributors**: Collaborate with Editors and Maintainers; Engage in task force meetings.
-- **Editors**: Coordinate with Task Force Conveners; Support cross-team communication.
-- **Task Force Conveners**: Facilitate collaboration within the task force; Coordinate with other conveners and the Working Group Chair.
-- **Working Group Chair**: Coordinate all task forces; Ensure alignment with project goals; Facilitate inter-task force collaboration.
-- **Maintainers**: Coordinate technical work across teams; Manage integration of contributions; Support cross-functional communication.
-- **Program Manager**: Ensure cohesive collaboration among all teams; Address process issues; Align team efforts with strategic goals.
-
-#### 4. Community & Engagement
-
-- **Contributors**: Engage with the community; Provide support to new contributors.
-- **Editors**: Encourage community participation; Facilitate discussions on editorial improvements.
-- **Task Force Conveners**: Engage with stakeholders; Promote task force activities; Gather feedback.
-- **Working Group Chair**: Facilitate community discussions; Engage with external stakeholders; Promote the project's mission.
-- **Maintainers**: Foster community engagement; Support new contributors; Mentor community members.
-- **Program Manager**: Primary contact for stakeholders; Maintain stakeholder engagement; Promote project visibility and community involvement.
-
-#### 5. Documentation & Reporting
-
-- **Contributors**: Contribute to documentation; Advocate for clarity and accessibility.
-- **Editors**: Oversee document updates; Ensure accuracy and adherence to editorial standards.
-- **Task Force Conveners**: Document task force activities; Ensure documentation reflects technical accuracy and completeness.
-- **Working Group Chair**: Ensure comprehensive documentation; Report task force activities to stakeholders; Address documentation gaps.
-- **Maintainers**: Maintain overall documentation; Keep communication channels updated; Ensure repository accuracy.
-- **Program Manager**: Comprehensive documentation; Prepare detailed status reports; Communicate project progress and challenges.
-
-#### 6. Monitoring & Maintenance
-
-- **Contributors**: Participate in monitoring discussions; Report issues.
-- **Editors**: Oversee editorial quality and consistency in documentation.
-- **Task Force Conveners**: Monitor task force-specific contributions; Ensure ongoing relevance and accuracy.
-- **Working Group Chair**: Monitor overall project quality; Ensure task forces are meeting their objectives; Address quality issues.
-- **Maintainers**: Regular monitoring of repositories; Ensure technical accuracy and compliance; Implement best practices.
-- **Program Manager**: Monitor overall project health and adherence to timelines; Ensure milestones are met.
-
-#### 7. Learning & Improvement
-
-- **Contributors**: Stay informed and updated; Participate in training sessions.
-- **Editors**: Conduct editorial reviews; Recommend improvements based on best practices.
-- **Task Force Conveners**: Facilitate technical learning within the task force; Implement improvements based on feedback.
-- **Working Group Chair**: Lead continuous improvement initiatives; Encourage innovation and the adoption of best practices.
-- **Maintainers**: Continuous learning and implementation of new technologies; Mentor team members.
-- **Program Manager**: Lead and promote a culture of continuous improvement; Facilitate training and professional development.
-
-#### 8. Stakeholder Management
-
-- **Contributors**: Provide feedback from the community; Participate in stakeholder discussions.
-- **Task Force Conveners**: Engage with stakeholders for feedback on task force outputs; Ensure stakeholder needs are addressed.
-- **Working Group Chair**: Serve as the primary liaison for stakeholders; Integrate stakeholder feedback into the project.
-- **Maintainers**: Engage with stakeholders on technical matters; Ensure stakeholder expectations are met.
-- **Program Manager**: Primary liaison for all stakeholder communication; Integrate feedback into strategic planning; Manage stakeholder relationships.
-
->Note: the group may decide to render the above content as a table:
+The table below outlines the key roles and responsibilities across eight critical areas of our project, designed to enhance collaboration, uphold standards, and promote community engagement.
 
 <table border="1">
   <thead>


### PR DESCRIPTION
The FOCUS group, led by the Maintainers, agreed to organize the roles and tasks assigned to FOCUS members.
The Maintainers group is encouraged to agree on the Contributors' tasks before moving into the other roles.