### PR TITLE
[Editorial] Update to do not allow Contributors to be eligible to join the Steering

### DIFF
--- a/operating_procedures.md
+++ b/operating_procedures.md
@@ -232,7 +232,7 @@ Table 3.0-1: Membership Benefits
 |                        | Eligible for a FOCUS (Working) Maintainer position                       |    Yes** |   N/A   |     Yes**   |
 | **Participation**                                                                                                                    |
 |                        | Eligible to join a Working Group                                         |    Yes   |   N/A   |     Yes     |
-|                        | Eligible to join the Steering Committee Meetings                         |    Yes   |   N/A   |     Yes***  |
+|                        | Eligible to join the Steering Committee Meetings                         |    Yes   |   N/A   |     No  |
 | **Contribution**                                                                                                                     |
 |                        | Contribute to Working Groups                                             |    Yes   |   N/A   |     Yes     |
 |                        | Propose new working groups                                               |    Yes   |   N/A   |     Yes     |
@@ -252,7 +252,6 @@ Table 3.0-1: Membership Benefits
 
 \* The FOCUS SC may appoint individuals to these roles at its discretion
 \*\* Approval by the FOCUS Group chairperson
-\*\*\* No voting rights
 
 # 4\. FOCUS Working Group (FG) 
 


### PR DESCRIPTION
This PR is set to "NO" for the **eligibility** of Contributors to join the Steering Committee.
This is based on the following fragment from the FOCUS Project Charter:

> “2.3. Contributor. Contributors may participate in Working Group(s) designated by the Steering Committee but do not participate on the Steering Committee and are not eligible to participate in decisions that require a Supermajority Vote. ” I will prepare a PR to update the table. The SC can invite Contributors as guests to any meeting, but Contributors don’t have the right to join the SC meetings. Also, SC Meeting Minutes are only available to SC Members.