### PR TITLE
[ADMIN] add three new SC members Adobe, Datadog and Citi

### DIFF
--- a/steering_committee.md
+++ b/steering_committee.md
@@ -19,6 +19,9 @@ The current members of the FOCUS Steering Committee are:
 | Roy Wolman                                         | Amazon                | 10/10/2023   | 10/10/2025    |
 | Tim O'Brien                                        | Walmart               | 10/10/2023   | 10/10/2025    |
 | Anne Johnston                                      | Capital One           | 10/10/2023   | 10/10/2025    |
+| Richard Steck | Adobe   | 11/08/2024 | 11/08/2026 |
+| Chris Harris | Datadog | 11/08/2024 | 11/08/2026 |
+| Amit Kinha | Citi    | 11/08/2024 | 11/08/2026 |
 
 #### Emeriti
 

--- a/steering_committee.md
+++ b/steering_committee.md
@@ -20,7 +20,7 @@ The current members of the FOCUS Steering Committee are:
 | Tim O'Brien                                        | Walmart               | 10/10/2023   | 10/10/2025    |
 | Anne Johnston                                      | Capital One           | 10/10/2023   | 10/10/2025    |
 | Richard Steck | Adobe   | 11/08/2024 | 11/08/2026 |
-| Chris Harris | Datadog | 11/08/2024 | 11/08/2026 |
+| Christopher Harris | Datadog | 11/08/2024 | 11/08/2026 |
 | Amit Kinha | Citi    | 11/08/2024 | 11/08/2026 |
 
 #### Emeriti


### PR DESCRIPTION
This PR reflects the outcome of the FOCUS Steering Committee Elections, announced on Nov 8. (see email: [Election Results: FOCUS Steering Committee](https://groups.google.com/a/finops.org/g/focus-steering/c/RjI6WO7FYbM))